### PR TITLE
Upgrade to inkjs 2.2.4 that enables mjs exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "inkjs": "*"
   },
   "devDependencies": {
-    "inkjs": "2.2.2",
+    "inkjs": "2.2.4",
     "@types/node": "20.9.4",
     "typescript": "5.3.2",
     "vite": "5.0.2"

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,8 @@ import path from "node:path";
 import fs from "node:fs";
 import EventEmitter from "node:events";
 
-import inkjs from "inkjs";
+import { Compiler, CompilerOptions } from "inkjs/full";
 import type { PluginOption } from "vite";
-
-const { Compiler, CompilerOptions } = inkjs;
 
 class Tracker {
   // Track dependencies of main ink files for hot reloading
@@ -62,8 +60,7 @@ export function ink(): PluginOption {
 }
 
 function generateStoryModule(storyData: string) {
-  // Importing from inkjs/engine/Story breaks the production build so we import from a pre-bundled ink (engine only, no compiler)
-  return `import { Story } from "inkjs/dist/ink-es6";
+  return `import { Story } from "inkjs";
 const story = new Story(${storyData});
 
 let _callback;


### PR DESCRIPTION
Latest inkjs expose an mjs build for use with imports