### PR TITLE
Updated readme with proper reference d.ts based on npm dist

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ TypeScript doesn't know that `.ink` files export a Story.
 You can tell it by adding a `ink-env.d.ts` file in your `src/` folder:
 
 ```
-/// <reference types="vite-plugin-ink/global" />
+/// <reference types="vite-plugin-ink/ink" />
 ```
 
 (you can also add this line to the existing `vite-env.d.ts`.)


### PR DESCRIPTION
I was running into issues using the vite plugin with this declaration:

```d.ts
/// <reference types="vite-plugin-ink/global" />
```

After checking the npm distribution, I noticed that its labeled `ink.d.ts`. Not sure if this was user error or the fact I'm using electron, but I was able to fix it by changing the reference to...
```d.ts
/// <reference types="vite-plugin-ink/ink" />
```

So I figured I'd send a PR with the updated readme.